### PR TITLE
Add ELASTIC_RESPONSE_SIZE to config.py and use it for genre and person

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -31,8 +31,10 @@ class Settings(BaseSettings):
 
     REDIS_EXCEPTIONS: Any = (RedisError,)
 
+    ELASTIC_RESPONSE_SIZE: int = 1000
+
     # Настройки кеширования
-    FILM_CACHE_EXPIRE_IN_SECONDS: int = 300
+    CACHE_EXPIRE_IN_SECONDS: int = 300
 
     NOT_FOUND: ClassVar[bytes] = b'"not_found"'
 

--- a/src/services/genre_service.py
+++ b/src/services/genre_service.py
@@ -6,7 +6,7 @@ from fastapi import Depends
 from pydantic import BaseModel
 
 from src.core.exceptions import CheckCacheError, CheckElasticError
-from src.db.elastic import get_elastic
+from src.db.elastic import get_elastic, settings
 from src.db.redis_client import get_redis
 from src.models.models import GenreBase
 from src.services.base_service import BaseService
@@ -67,7 +67,9 @@ class GenreService(BaseService):
         # Если нет в кеше, ищем в Elasticsearch
 
         # Формируем тело запроса для Elasticsearch
-        body = {"query": {"match_all": {}}}
+        body = {
+            "query": {"match_all": {}}, "size" : settings.ELASTIC_RESPONSE_SIZE
+        }
 
         # Проверяем наличие результата в Elasticsearch
         try:
@@ -98,7 +100,7 @@ class GenreService(BaseService):
         model = GenreBase
 
         # Формируем тело запроса для Elasticsearch
-        body = {"query": {}}
+        body = {"query": {}, "size" : settings.ELASTIC_RESPONSE_SIZE}
 
         #  Поиск, если есть
         if query:

--- a/src/services/person_service.py
+++ b/src/services/person_service.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from fastapi import Depends
 from pydantic import BaseModel
 
+from src.core.config import settings
 from src.core.exceptions import CheckCacheError, CheckElasticError
 from src.db.elastic import get_elastic
 from src.db.redis_client import get_redis
@@ -109,7 +110,7 @@ class PersonService(BaseService):
                 },
             ],
             "minimum_should_match": 1,
-        }}}
+        }}, "size" : settings.ELASTIC_RESPONSE_SIZE}
 
         # Проверяем наличие результата в Elasticsearch
         try:

--- a/src/utils/cache_service.py
+++ b/src/utils/cache_service.py
@@ -13,7 +13,7 @@ class CacheService:
     def __init__(
         self,
         redis_client: Redis,
-        cache_expire: int = settings.FILM_CACHE_EXPIRE_IN_SECONDS,
+        cache_expire: int = settings.CACHE_EXPIRE_IN_SECONDS,
     ):
         self.redis_client = redis_client
         self.cache_expire = cache_expire


### PR DESCRIPTION
Добавил в тела запросов для эластика размер в 1000 записей, для тех ендпоинтов где подразумевается получить все записи. Со scroll не стал заморачиваться, так как решил, что будет достаточно и 1000.